### PR TITLE
Add Subpost model and one-to-many relation to Post in Prisma schema

### DIFF
--- a/prisma/migrations/20250915081725_add_subpost_model/migration.sql
+++ b/prisma/migrations/20250915081725_add_subpost_model/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "public"."Subpost" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Subpost_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Subpost" ADD CONSTRAINT "Subpost_postId_fkey" FOREIGN KEY ("postId") REFERENCES "public"."Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 model User {
   id               String    @id @default(uuid())
   walletAddress    String?   @unique
-  email            String?    @unique
+  email            String?   @unique
   name             String?
   password         String?
   role             Role      @default(USER)
@@ -58,7 +58,17 @@ model Post {
   subcategories String[]  @default([])
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+  subposts      Subpost[]
 
   @@index([categories], type: Gin)
   @@index([subcategories], type: Gin)
+}
+
+model Subpost {
+  id        String   @id @default(uuid())
+  content   String
+  postId    String
+  post      Post     @relation(fields: [postId], references: [id])
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION

**Description:**  
This PR updates the Prisma schema to support hierarchical content by:
- Adding a new `Subpost` model for child entries under a post.
- Establishing a one-to-many relationship between `Post` and `Subpost` (each post can have multiple subposts).
- Ensuring the `Post` model includes a `title` field.
- Including timestamps (`createdAt`, `updatedAt`) for both models.

These changes enable posts to have associated subposts, supporting threaded or nested content structures.