### PR TITLE
Add seed script improvements: limit, cleanup, and data reset

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,3 +1,6 @@
+if (process.env.NODE_ENV === "production") {
+  throw new Error("Seeding is disabled in production to prevent data loss.");
+}
 
 import { faker } from "@faker-js/faker";
 import { PrismaClient, Sentiment, Source } from "@prisma/client";
@@ -10,7 +13,13 @@ async function main() {
   await prisma.post.deleteMany({});
   await prisma.user.deleteMany({});
   // Seed Users
-  for (let i = 0; i < 5; i++) {
+
+  const MAX_USERS = 5;
+  const MAX_POSTS = 10;
+  const MIN_SUBPOSTS = 5;
+  const MAX_SUBPOSTS = 20;
+
+  for (let i = 0; i < MAX_USERS; i++) {
     await prisma.user.create({
       data: {
         walletAddress: faker.finance.ethereumAddress(),
@@ -23,51 +32,39 @@ async function main() {
   }
 
   // Seed Posts with Subposts
-  const maxPosts = 10;
-  const maxSubposts = 20;
-  let subpostsCreated = 0;
-  for (let i = 0; i < maxPosts; i++) {
-    const remainingSubposts = maxSubposts - subpostsCreated;
-    if (remainingSubposts <= 0) break;
-    const subpostCount = faker.number.int({ min: 1, max: Math.min(6, remainingSubposts) });
-
-    const createdCount = await prisma.$transaction(async (tx) => {
-      const post = await tx.post.create({
-        data: {
-          title: faker.lorem.sentence(),
-          bullishSummary: faker.lorem.paragraph(),
-          bearishSummary: faker.lorem.paragraph(),
-          neutralSummary: faker.lorem.paragraph(),
-          totalSubposts: 0,
-        },
-      });
-
-      const subposts = Array.from({ length: subpostCount }).map(() => ({
-        content: faker.lorem.paragraph(),
-        sentiment: faker.helpers.arrayElement([
-          Sentiment.BULLISH,
-          Sentiment.BEARISH,
-          Sentiment.NEUTRAL,
-        ]),
-        source: faker.helpers.arrayElement([
-          Source.REDDIT,
-          Source.TWITTER,
-          Source.YOUTUBE,
-          Source.TELEGRAM,
-          Source.FARCASTER,
-        ]),
-        categories: [faker.lorem.word(), faker.lorem.word()],
-        subcategories: [faker.lorem.word(), faker.lorem.word()],
-        link: faker.internet.url(),
-        postId: post.id,
-      }));
-
-      await tx.subpost.createMany({ data: subposts });
-      await tx.post.update({ where: { id: post.id }, data: { totalSubposts: subpostCount } });
-      return subpostCount;
+  for (let i = 0; i < MAX_POSTS; i++) {
+    const subpostCount = faker.number.int({ min: MIN_SUBPOSTS, max: MAX_SUBPOSTS });
+    await prisma.post.create({
+      data: {
+        title: faker.lorem.sentence(),
+        bullishSummary: faker.helpers.maybe(() => faker.lorem.paragraph(), { probability: 0.7 }),
+        bearishSummary: faker.helpers.maybe(() => faker.lorem.paragraph(), { probability: 0.7 }),
+        neutralSummary: faker.helpers.maybe(() => faker.lorem.paragraph(), { probability: 0.7 }),
+        totalSubposts: subpostCount,
+        subposts: {
+          createMany: {
+            data: Array.from({ length: subpostCount }).map(() => ({
+              content: faker.lorem.paragraph({ min: 3, max: 5 }),
+              sentiment: faker.helpers.arrayElement([
+                Sentiment.BULLISH,
+                Sentiment.BEARISH,
+                Sentiment.NEUTRAL,
+              ]),
+              source: faker.helpers.arrayElement([
+                Source.REDDIT,
+                Source.TWITTER,
+                Source.YOUTUBE,
+                Source.TELEGRAM,
+                Source.FARCASTER,
+              ]),
+              categories: faker.helpers.arrayElements([faker.lorem.word(), faker.lorem.word()], { min: 1, max: 2 }),
+              subcategories: faker.helpers.arrayElements([faker.lorem.word(), faker.lorem.word()], { min: 2, max: 5 }),
+              link: faker.internet.url(),
+            }))
+          }
+        }
+      }
     });
-
-    subpostsCreated += createdCount;
   }
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,88 +1,76 @@
+
 import { faker } from "@faker-js/faker";
 import { PrismaClient, Sentiment, Source } from "@prisma/client";
-
-const SENTIMENTS = ["BULLISH", "BEARISH", "NEUTRAL"];
-const SOURCES = ["REDDIT", "TWITTER", "YOUTUBE", "TELEGRAM", "FARCASTER"];
-const CATEGORIES = [
-  "DeFi",
-  "NFTs",
-  "Trading",
-  "Staking",
-  "Passive Income",
-  "Altcoins",
-  "Market Trends",
-  "Safety",
-  "Tips",
-  "Earning",
-];
-const SUB_CATEGORIES = [
-  "Liquidity Pools",
-  "Yield Farming",
-  "Bitcoin",
-  "Ethereum",
-  "Opportunities",
-  "Security",
-  "2025",
-  "Bullish",
-  "Bearish",
-  "Regulation",
-  "Wallets",
-  "Exchanges",
-  "Layer 2",
-  "Airdrops",
-  "Governance",
-];
-
-
-const TITLES = [
-  "How to earn crypto in 2025",
-  "Passive income with DeFi",
-  "Crypto market trends 2025",
-  "Altcoin earning opportunities",
-  "Crypto safety tips",
-  "NFTs: The next big thing",
-  "Staking strategies for Ethereum",
-  "DeFi risks and rewards",
-  "Top 5 crypto wallets",
-  "Regulation and the future of crypto",
-];
-
-const CONTENTS = [
-  "Learn how to earn Bitcoin and Ethereum by staking and trading.",
-  "Liquidity pools and yield farming for passive crypto income.",
-  "Analysis of bullish trends in the crypto market for 2025.",
-  "Explore new earning opportunities with altcoins.",
-  "Tips for earning crypto safely and securely.",
-  "NFTs are changing the digital art landscape.",
-  "How to maximize returns with Ethereum staking.",
-  "Understanding the risks and rewards in DeFi protocols.",
-  "A review of the top 5 crypto wallets for security.",
-  "How regulation could impact the future of cryptocurrencies.",
-];
 
 const prisma = new PrismaClient();
 
 async function main() {
-  const posts = Array.from({ length: 10 }).map((_, i) => ({
-    title: TITLES[i % TITLES.length],
-    content: CONTENTS[i % CONTENTS.length],
-    sentiment: faker.helpers.arrayElement(SENTIMENTS) as Sentiment,
-    source: faker.helpers.arrayElement(SOURCES) as Source,
-    categories: faker.helpers.arrayElements(
-      CATEGORIES,
-      faker.number.int({ min: 1, max: 2 })
-    ),
-    subcategories: faker.helpers.arrayElements(
-      SUB_CATEGORIES,
-      faker.number.int({ min: 3, max: 5 })
-    ),
-  }));
-  await prisma.$transaction([
-    prisma.post.deleteMany({}),
-    prisma.post.createMany({ data: posts }),
-  ]);
+  // Delete existing data to prevent stacking
+  await prisma.subpost.deleteMany({});
+  await prisma.post.deleteMany({});
+  await prisma.user.deleteMany({});
+  // Seed Users
+  for (let i = 0; i < 5; i++) {
+    await prisma.user.create({
+      data: {
+        walletAddress: faker.finance.ethereumAddress(),
+        email: faker.internet.email(),
+        name: faker.person.fullName(),
+        password: faker.internet.password(),
+        image: faker.image.avatar(),
+      },
+    });
+  }
 
-  console.log("Seeded 10 crypto-related posts with categories and subcategories!");
+  // Seed Posts with Subposts
+  const maxPosts = 10;
+  const maxSubposts = 20;
+  let subpostsCreated = 0;
+  for (let i = 0; i < maxPosts; i++) {
+    const post = await prisma.post.create({
+      data: {
+        title: faker.lorem.sentence(),
+        bullishSummary: faker.lorem.paragraph(),
+        bearishSummary: faker.lorem.paragraph(),
+        neutralSummary: faker.lorem.paragraph(),
+        totalSubposts: 0, // will update after subposts
+      },
+    });
+
+    // Calculate remaining subposts allowed
+    const remainingSubposts = maxSubposts - subpostsCreated;
+    if (remainingSubposts <= 0) break;
+    // Each post gets at least 1 subpost, max 6, but not exceeding maxSubposts
+    const subpostCount = Math.min(faker.number.int({ min: 1, max: 6 }), remainingSubposts);
+    const subposts = [];
+    for (let j = 0; j < subpostCount; j++) {
+      subposts.push({
+        content: faker.lorem.paragraph(),
+        sentiment: faker.helpers.arrayElement([
+          Sentiment.BULLISH,
+          Sentiment.BEARISH,
+          Sentiment.NEUTRAL,
+        ]),
+        source: faker.helpers.arrayElement([
+          Source.REDDIT,
+          Source.TWITTER,
+          Source.YOUTUBE,
+          Source.TELEGRAM,
+          Source.FARCASTER,
+        ]),
+        categories: [faker.lorem.word(), faker.lorem.word()],
+        subcategories: [faker.lorem.word(), faker.lorem.word()],
+        link: faker.internet.url(),
+        postId: post.id,
+      });
+    }
+    await prisma.subpost.createMany({ data: subposts });
+    await prisma.post.update({
+      where: { id: post.id },
+      data: { totalSubposts: subpostCount },
+    });
+    subpostsCreated += subpostCount;
+  }
 }
 
 main()


### PR DESCRIPTION

**PR Description:**  
- Updated the Prisma seed script to delete all existing User, Post, and Subpost records before seeding, preventing data stacking on repeated runs.
- Limited the number of seeded users to 5, posts to 10, and total subposts to 20 for more controlled test data.
- Ensured subposts are distributed across posts without exceeding the maximum.
- Improved data generation using faker.js for all relevant fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Richer demo data: seeds 5 users, 10 posts with Faker-generated titles, summaries, and 5–20 nested subposts each (with sentiment, source, categories, links).
- Bug Fixes
  - Added a production guard to prevent seeding in production environments.
- Refactor
  - Replaced static templates/constants with a dynamic, generation-driven seeding flow using configurable limits.
- Chores
  - Streamlined seeding path and removed noisy console output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->