### PR TITLE
feat: Refactor Prisma Schema and Update PostGallery Mock Data Structure

### DIFF
--- a/prisma/migrations/20250917074232_rename_to_post_group_and_post_model/migration.sql
+++ b/prisma/migrations/20250917074232_rename_to_post_group_and_post_model/migration.sql
@@ -1,0 +1,52 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `bearishSummary` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `bullishSummary` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `neutralSummary` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `title` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `totalSubposts` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the `Subpost` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `content` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `postGroupId` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `sentiment` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `source` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Post` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Subpost" DROP CONSTRAINT "Subpost_postId_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."Post" DROP COLUMN "bearishSummary",
+DROP COLUMN "bullishSummary",
+DROP COLUMN "neutralSummary",
+DROP COLUMN "title",
+DROP COLUMN "totalSubposts",
+ADD COLUMN     "categories" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "content" TEXT NOT NULL,
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "link" TEXT,
+ADD COLUMN     "postGroupId" TEXT NOT NULL,
+ADD COLUMN     "sentiment" "public"."Sentiment" NOT NULL,
+ADD COLUMN     "source" "public"."Source" NOT NULL,
+ADD COLUMN     "subcategories" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- DropTable
+DROP TABLE "public"."Subpost";
+
+-- CreateTable
+CREATE TABLE "public"."PostGroup" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "totalSubposts" INTEGER NOT NULL DEFAULT 0,
+    "bullishSummary" TEXT,
+    "bearishSummary" TEXT,
+    "neutralSummary" TEXT,
+
+    CONSTRAINT "PostGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "public"."Post" ADD CONSTRAINT "Post_postGroupId_fkey" FOREIGN KEY ("postGroupId") REFERENCES "public"."PostGroup"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250917075310_update_post_group_model/migration.sql
+++ b/prisma/migrations/20250917075310_update_post_group_model/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `totalSubposts` on the `PostGroup` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."PostGroup" DROP COLUMN "totalSubposts",
+ADD COLUMN     "totalposts" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,17 +48,17 @@ enum Source {
   FARCASTER
 }
 
-model Post {
-  id             String    @id @default(uuid())
+model PostGroup {
+  id             String  @id @default(uuid())
   title          String
-  subposts       Subpost[]
-  totalSubposts  Int       @default(0)
+  posts          Post[]
+  totalposts  Int     @default(0)
   bullishSummary String?
   bearishSummary String?
   neutralSummary String?
 }
 
-model Subpost {
+model Post {
   id            String    @id @default(uuid())
   content       String
   sentiment     Sentiment
@@ -66,8 +66,8 @@ model Subpost {
   categories    String[]  @default([])
   subcategories String[]  @default([])
   link          String?
-  postId        String
-  post          Post      @relation(fields: [postId], references: [id])
+  postGroupId   String
+  postGroup     PostGroup @relation(fields: [postGroupId], references: [id])
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -9,15 +9,15 @@ const prisma = new PrismaClient();
 
 async function main() {
   // Delete existing data to prevent stacking
-  await prisma.subpost.deleteMany({});
   await prisma.post.deleteMany({});
+  await prisma.postGroup.deleteMany({});
   await prisma.user.deleteMany({});
   // Seed Users
 
   const MAX_USERS = 5;
-  const MAX_POSTS = 10;
-  const MIN_SUBPOSTS = 5;
-  const MAX_SUBPOSTS = 20;
+  const MAX_POSTGROUP = 10;
+  const MIN_POSTS = 5;
+  const MAX_POSTS = 20;
 
   for (let i = 0; i < MAX_USERS; i++) {
     await prisma.user.create({
@@ -31,19 +31,19 @@ async function main() {
     });
   }
 
-  // Seed Posts with Subposts
-  for (let i = 0; i < MAX_POSTS; i++) {
-    const subpostCount = faker.number.int({ min: MIN_SUBPOSTS, max: MAX_SUBPOSTS });
-    await prisma.post.create({
+  // Seed PostGroups with Posts
+  for (let i = 0; i < MAX_POSTGROUP; i++) {
+    const postCount = faker.number.int({ min: MIN_POSTS, max: MAX_POSTS });
+    await prisma.postGroup.create({
       data: {
         title: faker.lorem.sentence(),
         bullishSummary: faker.helpers.maybe(() => faker.lorem.paragraph(), { probability: 0.7 }),
         bearishSummary: faker.helpers.maybe(() => faker.lorem.paragraph(), { probability: 0.7 }),
         neutralSummary: faker.helpers.maybe(() => faker.lorem.paragraph(), { probability: 0.7 }),
-        totalSubposts: subpostCount,
-        subposts: {
+        totalposts: postCount,
+        posts: {
           createMany: {
-            data: Array.from({ length: subpostCount }).map(() => ({
+            data: Array.from({ length: postCount }).map(() => ({
               content: faker.lorem.paragraph({ min: 3, max: 5 }),
               sentiment: faker.helpers.arrayElement([
                 Sentiment.BULLISH,

--- a/src/components/PostComponents/PostGallery.tsx
+++ b/src/components/PostComponents/PostGallery.tsx
@@ -2,6 +2,8 @@
 
 import { CiChat1 } from "react-icons/ci";
 import { FaTwitter, FaLinkedin, FaReddit } from "react-icons/fa";
+import { IoIosTrendingUp, IoIosTrendingDown } from "react-icons/io";
+import { FiMinus } from "react-icons/fi";
 
 import { Card, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import TagRenderer from "./TagRenderer";
@@ -141,6 +143,39 @@ export function PostCard({ postGroup }: { postGroup: PostGroup }) {
     bearish: (sentimentCounts.bearish / totalPosts) * 100,
   };
 
+  // Determine dominant sentiment and description
+  const getDominantSentiment = () => {
+    const max = Math.max(
+      sentimentCounts.bullish,
+      sentimentCounts.neutral,
+      sentimentCounts.bearish
+    );
+
+    if (
+      sentimentCounts.bullish === sentimentCounts.neutral &&
+      sentimentCounts.neutral === sentimentCounts.bearish
+    ) {
+      return { sentiment: "NEUTRAL", description: postGroup.neutralSummary };
+    }
+
+    if (sentimentCounts.bullish === max) {
+      return { sentiment: "BULLISH", description: postGroup.bullishSummary };
+    } else if (sentimentCounts.bearish === max) {
+      return { sentiment: "BEARISH", description: postGroup.bearishSummary };
+    } else {
+      return { sentiment: "NEUTRAL", description: postGroup.neutralSummary };
+    }
+  };
+
+  const dominantSentiment = getDominantSentiment();
+
+  const sentimentColor =
+    dominantSentiment.sentiment === "BULLISH"
+      ? "text-green-700 bg-green-100"
+      : dominantSentiment.sentiment === "BEARISH"
+      ? "text-red-700 bg-red-100"
+      : "text-gray-700 bg-gray-100";
+
   // Get source counts
   const sourceCounts = postGroup.posts.reduce((acc, post) => {
     acc[post.source] = (acc[post.source] || 0) + 1;
@@ -163,13 +198,26 @@ export function PostCard({ postGroup }: { postGroup: PostGroup }) {
         </CardTitle>
 
         <CardDescription className="text-xs text-gray-600 mb-3 line-clamp-3">
-          {postGroup.bullishSummary ||
-            postGroup.neutralSummary ||
-            postGroup.bearishSummary}
+          {dominantSentiment.description}
         </CardDescription>
 
-        {/* Post count indicator */}
-        <div className="flex items-center gap-1 mb-3">
+        {/* Sentiment tag and post count */}
+        <div className="flex items-center gap-2 mb-3">
+          <span
+            className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${sentimentColor}`}
+          >
+            {dominantSentiment.sentiment === "BULLISH" && (
+              <IoIosTrendingUp className="text-green-600 w-4 h-4" />
+            )}
+            {dominantSentiment.sentiment === "BEARISH" && (
+              <IoIosTrendingDown className="text-red-600 w-4 h-4" />
+            )}
+            {dominantSentiment.sentiment === "NEUTRAL" && (
+              <FiMinus className="text-gray-600 w-4 h-4" />
+            )}
+            {dominantSentiment.sentiment.charAt(0) +
+              dominantSentiment.sentiment.slice(1).toLowerCase()}
+          </span>
           <div className="flex items-center gap-1 text-xs text-gray-600">
             <CiChat1 className="w-3 h-3" />
             {postGroup.totalposts} posts

--- a/src/components/PostComponents/PostGallery.tsx
+++ b/src/components/PostComponents/PostGallery.tsx
@@ -13,27 +13,27 @@ type Source = {
   count: number;
 };
 
-type PostData = {
+type PostGroup = {
   title: string;
-  description: string;
+  content: string;
   sentiment: Sentiment;
   sentimentBar: { bullish: number; neutral: number; bearish: number };
   postCount: number;
-  sources: Source[];
+  source: Source[];
   categories: string[];
   subcategories?: string[];
 };
 
 // Mock data array
-const mockPostsData: PostData[] = [
+const mockPostsData: PostGroup[] = [
   {
     title: "Bitcoin Institutional Adoption & Market Sentiment",
-    description:
+    content:
       "Major financial institutions showing increased interest in Bitcoin with positive analyst reports...",
     sentiment: "BULLISH",
     sentimentBar: { bullish: 60, neutral: 25, bearish: 15 },
     postCount: 24,
-    sources: [
+    source: [
       {
         name: "Twitter",
         count: 12,
@@ -52,12 +52,12 @@ const mockPostsData: PostData[] = [
   },
   {
     title: "Ethereum DeFi Protocol Updates",
-    description:
+    content:
       "New developments in decentralized finance protocols showing promising growth patterns...",
     sentiment: "NEUTRAL",
     sentimentBar: { bullish: 30, neutral: 50, bearish: 20 },
     postCount: 18,
-    sources: [
+    source: [
       {
         name: "Twitter",
         count: 10,
@@ -72,12 +72,12 @@ const mockPostsData: PostData[] = [
   },
   {
     title: "Market Volatility Analysis",
-    description:
+    content:
       "Recent market downturn showing concerning trends across major cryptocurrencies...",
     sentiment: "BEARISH",
     sentimentBar: { bullish: 15, neutral: 25, bearish: 60 },
     postCount: 32,
-    sources: [
+    source: [
       {
         name: "LinkedIn",
         count: 15,
@@ -93,11 +93,11 @@ const mockPostsData: PostData[] = [
 ];
 
 type PostsGalleryProps = {
-  posts?: PostData[];
+  posts?: PostGroup[];
 };
 
 // Single card component
-export function SinglePostCard({ post }: { post: PostData }) {
+export function SinglePostCard({ post }: { post: PostGroup }) {
   const sentimentColor =
     post.sentiment === "BULLISH"
       ? "text-green-700 bg-green-100"
@@ -113,7 +113,7 @@ export function SinglePostCard({ post }: { post: PostData }) {
         </CardTitle>
 
         <CardDescription className="text-[8px] text-gray-600 mb-2 line-clamp-2">
-          {post.description}
+          {post.content}
         </CardDescription>
 
         {/* Sentiment indicators */}
@@ -150,7 +150,7 @@ export function SinglePostCard({ post }: { post: PostData }) {
 
         {/* Source Tags */}
         <div className="flex flex-wrap gap-1 mb-2 text-[8px]">
-          {post.sources.map((src, idx) => {
+          {post.source.map((src, idx) => {
             let pillClass =
               "px-2 py-0.5 rounded-full flex items-center gap-1 border text-[9px] font-medium";
             let icon = null;

--- a/src/components/PostComponents/PostGallery.tsx
+++ b/src/components/PostComponents/PostGallery.tsx
@@ -1,185 +1,231 @@
 "use client";
 
-import { IoIosTrendingUp } from "react-icons/io";
 import { CiChat1 } from "react-icons/ci";
 import { FaTwitter, FaLinkedin, FaReddit } from "react-icons/fa";
 
 import { Card, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import TagRenderer from "./TagRenderer";
-import { Sentiment } from "@prisma/client";
-
-type Source = {
-  name: string;
-  count: number;
-};
+import { Sentiment, Source } from "@prisma/client";
 
 type PostGroup = {
+  id: string;
   title: string;
+  posts: Post[];
+  totalposts: number;
+  bullishSummary?: string | null;
+  bearishSummary?: string | null;
+  neutralSummary?: string | null;
+};
+
+type Post = {
+  id: string;
   content: string;
   sentiment: Sentiment;
-  sentimentBar: { bullish: number; neutral: number; bearish: number };
-  postCount: number;
-  source: Source[];
+  source: Source;
   categories: string[];
-  subcategories?: string[];
+  subcategories: string[];
+  link?: string | null;
+  createdAt: string;
+  updatedAt: string;
 };
 
 // Mock data array
-const mockPostsData: PostGroup[] = [
+const mockPostGroup: PostGroup[] = [
   {
-    title: "Bitcoin Institutional Adoption & Market Sentiment",
-    content:
-      "Major financial institutions showing increased interest in Bitcoin with positive analyst reports...",
-    sentiment: "BULLISH",
-    sentimentBar: { bullish: 60, neutral: 25, bearish: 15 },
-    postCount: 24,
-    source: [
+    id: "group1",
+    title: "Bitcoin Historical Milestones & Market Impact",
+    totalposts: 3,
+    bullishSummary:
+      "Bitcoin's journey from pizza transactions to trillion-dollar adoption shows incredible growth potential",
+    bearishSummary:
+      "Historical volatility and speculative nature raise concerns about sustainable growth",
+    neutralSummary:
+      "Bitcoin's evolution reflects both opportunities and challenges in the cryptocurrency space",
+    posts: [
       {
-        name: "Twitter",
-        count: 12,
+        id: "post1",
+        content:
+          "Empery Digital\n@EMPD_BTC\n·\n11m\nBitcoin Firsts that changed everything:\n- $4B Pizza\n- A nation bets on BTC\n- Wall Street embraces it\n- The Trillion-Dollar Club\nFrom a pizza order to reshaping global finance.\n#Bitcoin #BTC #Blockchain #EmperyDigital",
+        sentiment: "BULLISH",
+        source: "TWITTER",
+        categories: ["Cryptocurrency", "Market Analysis"],
+        subcategories: ["Bitcoin", "Milestones", "Adoption"],
+        link: null,
+        createdAt: "2025-09-16T12:00:00.000Z",
+        updatedAt: "2025-09-16T12:00:00.000Z",
       },
       {
-        name: "LinkedIn",
-        count: 8,
+        id: "post2",
+        content:
+          "Empery Digital\n@EMPD_BTC\n·\n11m\nSome notable events in Bitcoin's history include:\n- The purchase of pizza with Bitcoin\n- A country adopting BTC\n- Increased interest from Wall Street\n- Joining the Trillion-Dollar Club\nThese milestones reflect Bitcoin's evolving role in finance.\n#Bitcoin #BTC #Blockchain #EmperyDigital",
+        sentiment: "NEUTRAL",
+        source: "TWITTER",
+        categories: ["Cryptocurrency", "Market Analysis"],
+        subcategories: ["Bitcoin", "Milestones", "Adoption"],
+        link: null,
+        createdAt: "2025-09-16T12:00:00.000Z",
+        updatedAt: "2025-09-16T12:00:00.000Z",
       },
       {
-        name: "Reddit",
-        count: 4,
+        id: "post3",
+        content:
+          "Empery Digital\n@EMPD_BTC\n·\n11m\nRecent events in Bitcoin's history have raised concerns:\n- The infamous $4B pizza purchase\n- A nation risking its economy on BTC\n- Wall Street's speculative involvement\n- Entering the Trillion-Dollar Club amid volatility\nFrom a simple transaction to ongoing financial uncertainty.\n#Bitcoin #BTC #Blockchain #EmperyDigital",
+        sentiment: "BEARISH",
+        source: "TWITTER",
+        categories: ["Cryptocurrency", "Market Analysis"],
+        subcategories: ["Bitcoin", "Milestones", "Risks"],
+        link: null,
+        createdAt: "2025-09-16T12:00:00.000Z",
+        updatedAt: "2025-09-16T12:00:00.000Z",
       },
     ],
-    categories: ["Bitcoin", "Institutional"],
-    subcategories: ["ETF", "Regulation", "Spot", "Futures"],
   },
   {
-    title: "Ethereum DeFi Protocol Updates",
-    content:
-      "New developments in decentralized finance protocols showing promising growth patterns...",
-    sentiment: "NEUTRAL",
-    sentimentBar: { bullish: 30, neutral: 50, bearish: 20 },
-    postCount: 18,
-    source: [
+    id: "group2",
+    title: "Ethereum DeFi Ecosystem Updates",
+    totalposts: 2,
+    bullishSummary:
+      "DeFi protocols showing strong innovation and growth in the Ethereum ecosystem",
+    bearishSummary:
+      "Regulatory concerns and high gas fees continue to challenge DeFi adoption",
+    neutralSummary:
+      "DeFi development continues with mixed signals from market and regulatory fronts",
+    posts: [
       {
-        name: "Twitter",
-        count: 10,
+        id: "post4",
+        content:
+          "Major DeFi protocol announces new lending features with improved yield opportunities for users",
+        sentiment: "BULLISH",
+        source: "REDDIT",
+        categories: ["Ethereum", "DeFi"],
+        subcategories: ["Lending", "Yield", "Innovation"],
+        link: "https://reddit.com/r/ethereum/defi-update",
+        createdAt: "2025-09-16T14:00:00.000Z",
+        updatedAt: "2025-09-16T14:00:00.000Z",
       },
       {
-        name: "Reddit",
-        count: 8,
+        id: "post5",
+        content:
+          "Gas fees on Ethereum network surge to new highs, affecting DeFi transaction costs",
+        sentiment: "BEARISH",
+        source: "TWITTER",
+        categories: ["Ethereum", "DeFi"],
+        subcategories: ["Gas Fees", "Network Congestion"],
+        link: null,
+        createdAt: "2025-09-16T15:00:00.000Z",
+        updatedAt: "2025-09-16T15:00:00.000Z",
       },
     ],
-    categories: ["Ethereum"],
-    subcategories: ["Lending", "DEX", "Staking", "Yield", "Bridge"],
-  },
-  {
-    title: "Market Volatility Analysis",
-    content:
-      "Recent market downturn showing concerning trends across major cryptocurrencies...",
-    sentiment: "BEARISH",
-    sentimentBar: { bullish: 15, neutral: 25, bearish: 60 },
-    postCount: 32,
-    source: [
-      {
-        name: "LinkedIn",
-        count: 15,
-      },
-      {
-        name: "Reddit",
-        count: 17,
-      },
-    ],
-    categories: ["Market", "Volatility"],
-    subcategories: ["Crash", "Recovery", "Bear", "Bull"],
   },
 ];
 
 type PostsGalleryProps = {
-  posts?: PostGroup[];
+  postGroups: PostGroup[];
 };
 
-// Single card component
-export function SinglePostCard({ post }: { post: PostGroup }) {
-  const sentimentColor =
-    post.sentiment === "BULLISH"
-      ? "text-green-700 bg-green-100"
-      : post.sentiment === "BEARISH"
-      ? "text-red-700 bg-red-100"
-      : "text-gray-700 bg-gray-100";
+// Single card component for PostGroup
+export function PostCard({ postGroup }: { postGroup: PostGroup }) {
+  // Calculate sentiment distribution from posts
+  const sentimentCounts = postGroup.posts.reduce(
+    (acc, post) => {
+      acc[post.sentiment.toLowerCase() as keyof typeof acc]++;
+      return acc;
+    },
+    { bullish: 0, neutral: 0, bearish: 0 }
+  );
+
+  const totalPosts = postGroup.posts.length;
+  const sentimentBar = {
+    bullish: (sentimentCounts.bullish / totalPosts) * 100,
+    neutral: (sentimentCounts.neutral / totalPosts) * 100,
+    bearish: (sentimentCounts.bearish / totalPosts) * 100,
+  };
+
+  // Get source counts
+  const sourceCounts = postGroup.posts.reduce((acc, post) => {
+    acc[post.source] = (acc[post.source] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  // Get all categories and subcategories
+  const allCategories = [
+    ...new Set(postGroup.posts.flatMap((post) => post.categories)),
+  ];
+  const allSubcategories = [
+    ...new Set(postGroup.posts.flatMap((post) => post.subcategories)),
+  ];
 
   return (
-    <Card className="w-54 h-66 font-sans">
-      <CardHeader className="p-2">
-        <CardTitle className="text-[10px] font-semibold leading-tight mb-1">
-          {post.title}
+    <Card className="w-72 h-80 font-sans">
+      <CardHeader className="p-3">
+        <CardTitle className="text-sm font-semibold leading-tight mb-2">
+          {postGroup.title}
         </CardTitle>
 
-        <CardDescription className="text-[8px] text-gray-600 mb-2 line-clamp-2">
-          {post.content}
+        <CardDescription className="text-xs text-gray-600 mb-3 line-clamp-3">
+          {postGroup.bullishSummary ||
+            postGroup.neutralSummary ||
+            postGroup.bearishSummary}
         </CardDescription>
 
-        {/* Sentiment indicators */}
-        <div className="flex items-center gap-1 mb-2">
-          <span
-            className={`inline-flex items-center gap-0.5 px-1 py-0.5 text-[8px] font-medium rounded ${sentimentColor}`}
-          >
-            <IoIosTrendingUp className="w-2 h-2" />
-            {post.sentiment}
-          </span>
-          <div className="flex items-center gap-0.5 text-[8px] text-gray-600">
-            <CiChat1 className="w-2 h-2" />
-            {post.postCount}
+        {/* Post count indicator */}
+        <div className="flex items-center gap-1 mb-3">
+          <div className="flex items-center gap-1 text-xs text-gray-600">
+            <CiChat1 className="w-3 h-3" />
+            {postGroup.totalposts} posts
           </div>
         </div>
 
         {/* Sentiment Bar */}
-        <div className="mb-2">
-          <div className="flex h-1 w-20 rounded overflow-hidden">
+        <div className="mb-3">
+          <div className="flex h-2 w-28 rounded overflow-hidden">
             <div
               className="bg-green-500"
-              style={{ flex: post.sentimentBar.bullish }}
+              style={{ flex: sentimentBar.bullish }}
             ></div>
             <div
               className="bg-gray-300"
-              style={{ flex: post.sentimentBar.neutral }}
+              style={{ flex: sentimentBar.neutral }}
             ></div>
             <div
               className="bg-red-500"
-              style={{ flex: post.sentimentBar.bearish }}
+              style={{ flex: sentimentBar.bearish }}
             ></div>
           </div>
         </div>
 
         {/* Source Tags */}
-        <div className="flex flex-wrap gap-1 mb-2 text-[8px]">
-          {post.source.map((src, idx) => {
+        <div className="flex flex-wrap gap-1 mb-3 text-xs">
+          {Object.entries(sourceCounts).map(([source, count]) => {
             let pillClass =
-              "px-2 py-0.5 rounded-full flex items-center gap-1 border text-[9px] font-medium";
+              "px-2 py-1 rounded-full flex items-center gap-1 border text-xs font-medium";
             let icon = null;
-            if (src.name === "Twitter") {
+            if (source === "TWITTER") {
               pillClass += " bg-blue-50 text-blue-600 border-blue-200";
-              icon = <FaTwitter className="w-2 h-2" />;
-            } else if (src.name === "LinkedIn") {
+              icon = <FaTwitter className="w-3 h-3" />;
+            } else if (source === "LINKEDIN") {
               pillClass += " bg-blue-50 text-blue-600 border-blue-200";
-              icon = <FaLinkedin className="w-2 h-2" />;
-            } else if (src.name === "Reddit") {
+              icon = <FaLinkedin className="w-3 h-3" />;
+            } else if (source === "REDDIT") {
               pillClass += " bg-orange-50 text-orange-600 border-orange-200";
-              icon = <FaReddit className="w-2 h-2" />;
+              icon = <FaReddit className="w-3 h-3" />;
             } else {
               pillClass += " bg-gray-50 text-gray-600 border-gray-200";
             }
             return (
-              <span key={src.name + idx} className={pillClass}>
+              <span key={source} className={pillClass}>
                 {icon}
-                {src.name} <span className="font-semibold">({src.count})</span>
+                {source} <span className="font-semibold">({count})</span>
               </span>
             );
           })}
         </div>
 
         {/* Category/Subcategory Tags */}
-        <div className="flex flex-wrap gap-0.5">
+        <div className="flex flex-wrap gap-1">
           <TagRenderer
-            categories={post.categories}
-            subcategories={post.subcategories}
+            categories={allCategories}
+            subcategories={allSubcategories}
           />
         </div>
       </CardHeader>
@@ -188,12 +234,12 @@ export function SinglePostCard({ post }: { post: PostGroup }) {
 }
 
 export default function PostsGallery({
-  posts = mockPostsData,
+  postGroups = mockPostGroup,
 }: PostsGalleryProps) {
   return (
     <div className="flex flex-row justify-start ml-30 gap-6 p-2">
-      {posts.map((post, index) => (
-        <SinglePostCard key={index} post={post} />
+      {postGroups.map((postGroup, index) => (
+        <PostCard key={index} postGroup={postGroup} />
       ))}
     </div>
   );

--- a/src/components/PostComponents/PostGallery.tsx
+++ b/src/components/PostComponents/PostGallery.tsx
@@ -7,7 +7,7 @@ import { FiMinus } from "react-icons/fi";
 
 import { Card, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import TagRenderer from "./TagRenderer";
-import { Sentiment, Source } from "@prisma/client";
+import type { Sentiment, Source } from "@prisma/client";
 
 type PostGroup = {
   id: string;
@@ -137,11 +137,14 @@ export function PostCard({ postGroup }: { postGroup: PostGroup }) {
   );
 
   const totalPosts = postGroup.posts.length;
-  const sentimentBar = {
-    bullish: (sentimentCounts.bullish / totalPosts) * 100,
-    neutral: (sentimentCounts.neutral / totalPosts) * 100,
-    bearish: (sentimentCounts.bearish / totalPosts) * 100,
-  };
+  const sentimentBar =
+    totalPosts > 0
+      ? {
+          bullish: (sentimentCounts.bullish / totalPosts) * 100,
+          neutral: (sentimentCounts.neutral / totalPosts) * 100,
+          bearish: (sentimentCounts.bearish / totalPosts) * 100,
+        }
+      : { bullish: 0, neutral: 0, bearish: 0 };
 
   // Determine dominant sentiment and description
   const getDominantSentiment = () => {

--- a/src/components/PostComponents/TagRenderer.tsx
+++ b/src/components/PostComponents/TagRenderer.tsx
@@ -30,7 +30,7 @@ export default function TagRenderer({
       {visibleTags.map((tag, idx) => (
         <span
           key={tag.value + idx}
-          className={`px-1 py-0.5 text-[7px] font-medium rounded-full ${
+          className={`flex items-center justify-center px-1 py-1 text-[7px] font-medium rounded-full ${
             tag.type === "category"
               ? "text-white bg-blue-500"
               : "text-blue-700 border border-blue-500 bg-transparent"


### PR DESCRIPTION


**PR Description:**  
- Renamed and refactored Prisma models: updated `PostGroup` and `Post` naming and relationships in `schema.prisma`.
- Updated mock data container in PostGallery.tsx from `mockPostsData` to `mockPostGroup` for consistency with schema changes.
- Adjusted component usage to reflect new mock data naming.
- Prepared codebase for further alignment between frontend types and backend schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced Post Groups to organize multiple posts under one title with group-level bullish/neutral/bearish summaries and total posts count; gallery/cards now display grouped summaries and aggregated sentiment/source info.

* Refactor
  * Consolidated previous sub-items into posts within PostGroups; per-post content, sentiment, source, categories, subcategories and timestamps moved to the new Post items; APIs/props updated to accept postGroups.

* Chores
  * Database migrations and seed data updated to the PostGroup → Post model and renamed total posts field.

* Style
  * Tag pill spacing and vertical centering improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->