### PR TITLE
feat: Add Bulk Ingest API Endpoint for Post Groups with Posts

### DIFF
--- a/src/app/api/post-groups/ingest/route.ts
+++ b/src/app/api/post-groups/ingest/route.ts
@@ -12,7 +12,6 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-
     let data;
     try {
         data = await req.json();
@@ -48,19 +47,10 @@ export async function POST(req: NextRequest) {
     }
     data = parseResult.data;
 
-    // Accept an array of post groups
-    if (!Array.isArray(data) || data.length === 0) {
-        return NextResponse.json({ error: "Request body must be a non-empty array of post groups" }, { status: 400 });
-    }
 
     const results = [];
     try {
         for (const group of data) {
-            if (!group.title) {
-                results.push({ error: "Missing title in post group", group });
-                continue;
-            }
-
             // Create the post group
             const createdGroup = await prisma.postGroup.create({
                 data: {
@@ -108,6 +98,7 @@ export async function POST(req: NextRequest) {
         }
         return NextResponse.json(results);
     } catch (e) {
-        return NextResponse.json({ error: "Database error", details: String(e) }, { status: 500 });
+        console.error("Database error during post-group ingest", e);
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
     }
 }

--- a/src/app/api/post-groups/ingest/route.ts
+++ b/src/app/api/post-groups/ingest/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+
+// Set this env variable in your deployment environment
+const INGEST_SECRET = process.env.INGEST_SECRET;
+
+export async function POST(req: NextRequest) {
+    const authHeader = req.headers.get("x-ingest-secret");
+
+    if (!INGEST_SECRET || authHeader !== INGEST_SECRET) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+
+    let data;
+    try {
+        data = await req.json();
+    } catch {
+        return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // Zod validation schema
+    const postSchema = z.object({
+        content: z.string(),
+        sentiment: z.enum(["BULLISH", "NEUTRAL", "BEARISH"]),
+        source: z.enum(["REDDIT", "TWITTER", "YOUTUBE", "TELEGRAM", "FARCASTER"]),
+        categories: z.array(z.string()),
+        subcategories: z.array(z.string()),
+        link: z.string().optional(),
+        createdAt: z.string().datetime().optional(),
+        updatedAt: z.string().datetime().optional(),
+    });
+
+    const postGroupSchema = z.object({
+        title: z.string(),
+        bullishSummary: z.string().optional(),
+        bearishSummary: z.string().optional(),
+        neutralSummary: z.string().optional(),
+        posts: z.array(postSchema).optional(),
+    });
+
+    const postGroupsSchema = z.array(postGroupSchema);
+
+    const parseResult = postGroupsSchema.safeParse(data);
+    if (!parseResult.success) {
+        return NextResponse.json({ error: "Validation failed", details: parseResult.error.flatten() }, { status: 400 });
+    }
+    data = parseResult.data;
+
+    // Accept an array of post groups
+    if (!Array.isArray(data) || data.length === 0) {
+        return NextResponse.json({ error: "Request body must be a non-empty array of post groups" }, { status: 400 });
+    }
+
+    const results = [];
+    try {
+        for (const group of data) {
+            if (!group.title) {
+                results.push({ error: "Missing title in post group", group });
+                continue;
+            }
+
+            // Create the post group
+            const createdGroup = await prisma.postGroup.create({
+                data: {
+                    title: group.title,
+                    totalposts: Array.isArray(group.posts) ? group.posts.length : 0,
+                    bullishSummary: group.bullishSummary,
+                    bearishSummary: group.bearishSummary,
+                    neutralSummary: group.neutralSummary,
+                },
+            });
+
+            // Create posts for this group using createMany
+            if (Array.isArray(group.posts) && group.posts.length > 0) {
+                await prisma.post.createMany({
+                    data: group.posts.map((post: {
+                        content: string;
+                        sentiment: "BULLISH" | "NEUTRAL" | "BEARISH";
+                        source: "REDDIT" | "TWITTER" | "YOUTUBE" | "TELEGRAM" | "FARCASTER";
+                        categories: string[];
+                        subcategories: string[];
+                        link?: string;
+                        createdAt?: string;
+                        updatedAt?: string;
+                    }) => ({
+                        content: post.content,
+                        sentiment: post.sentiment,
+                        source: post.source,
+                        categories: post.categories,
+                        subcategories: post.subcategories,
+                        link: post.link,
+                        postGroupId: createdGroup.id,
+                        createdAt: post.createdAt ? new Date(post.createdAt) : undefined,
+                        updatedAt: post.updatedAt ? new Date(post.updatedAt) : undefined,
+                    })),
+                });
+            }
+
+            // Fetch the group with its posts
+            const groupWithPosts = await prisma.postGroup.findUnique({
+                where: { id: createdGroup.id },
+                include: { posts: true },
+            });
+
+            results.push({ success: true, postGroup: groupWithPosts });
+        }
+        return NextResponse.json(results);
+    } catch (e) {
+        return NextResponse.json({ error: "Database error", details: String(e) }, { status: 500 });
+    }
+}

--- a/src/app/api/post-groups/ingest/route.ts
+++ b/src/app/api/post-groups/ingest/route.ts
@@ -9,14 +9,8 @@ const INGEST_SECRET = process.env.INGEST_SECRET;
 // Zod validation schema (moved outside handler for efficiency)
 const postSchema = z.object({
     content: z.string(),
-    sentiment: z.enum([Sentiment.BULLISH, Sentiment.NEUTRAL, Sentiment.BEARISH]),
-    source: z.enum([
-        Source.REDDIT,
-        Source.TWITTER,
-        Source.YOUTUBE,
-        Source.TELEGRAM,
-        Source.FARCASTER,
-    ]),
+    sentiment: z.nativeEnum(Sentiment),
+    source: z.nativeEnum(Source),
     categories: z.array(z.string()),
     subcategories: z.array(z.string()),
     link: z.string().optional(),


### PR DESCRIPTION


**Description:**  
- Implements a protected POST API route at `/api/post-groups/ingest` that accepts an array of post groups, each with nested posts.
- Uses Zod for strict validation of incoming data structure.
- Efficiently creates each post group and its related posts using Prisma, returning the created groups with their posts in the response.
- Secures the endpoint with an environment variable (`INGEST_SECRET`) to prevent unauthorized access.
- Designed for bulk ingestion from external classifiers or services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a secure API endpoint to ingest post groups and their posts.
  - Requires a shared secret via request header; unauthorized requests are rejected.
  - Validates payloads (groups, posts, sentiments, sources, categories) and returns clear 400 errors on invalid JSON or data.
  - Supports partial success: processes valid groups while reporting per-group results.
  - Returns created groups with their posts and summaries when available.
  - Uses standard HTTP responses (400, 401, 500) for consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->